### PR TITLE
fix(haproxy): only configure httpchk for http/https monitors

### DIFF
--- a/internal/controller/backend/haproxy/haproxy_controller.go
+++ b/internal/controller/backend/haproxy/haproxy_controller.go
@@ -235,19 +235,25 @@ func (p *HAProxyProvider) GetPool(pool *lbv1.Pool) (*lbv1.Pool, error) {
 
 // CreatePool creates a server pool in the Load Balancer
 func (p *HAProxyProvider) CreatePool(pool *lbv1.Pool) error {
-	_, _, err := p.haproxy.Backend.CreateBackend(&backend.CreateBackendParams{
-		Data: &models.Backend{
-			Name:     pool.Name,
-			AdvCheck: "httpchk",
-			Balance: &models.Balance{
-				Algorithm: &p.lbmethod,
-			},
-			Mode: "tcp",
-			HttpchkParams: &models.HttpchkParams{
-				Method: "GET",
-				URI:    p.monitor.Path,
-			},
+	backendData := &models.Backend{
+		Name: pool.Name,
+		Balance: &models.Balance{
+			Algorithm: &p.lbmethod,
 		},
+		Mode: "tcp",
+	}
+
+	// Only configure httpchk for http/https monitor types
+	if p.monitor.MonitorType == "http" || p.monitor.MonitorType == "https" {
+		backendData.AdvCheck = "httpchk"
+		backendData.HttpchkParams = &models.HttpchkParams{
+			Method: "GET",
+			URI:    p.monitor.Path,
+		}
+	}
+
+	_, _, err := p.haproxy.Backend.CreateBackend(&backend.CreateBackendParams{
+		Data:          backendData,
 		Context:       p.ctx,
 		TransactionID: &p.transaction,
 	}, p.auth)
@@ -262,21 +268,27 @@ func (p *HAProxyProvider) CreatePool(pool *lbv1.Pool) error {
 
 // EditPool modifies a server pool in the Load Balancer
 func (p *HAProxyProvider) EditPool(pool *lbv1.Pool) error {
+	backendData := &models.Backend{
+		Name: pool.Name,
+		Balance: &models.Balance{
+			Algorithm: &p.lbmethod,
+		},
+		Mode: "tcp",
+	}
+
+	// Only configure httpchk for http/https monitor types
+	if p.monitor.MonitorType == "http" || p.monitor.MonitorType == "https" {
+		backendData.AdvCheck = "httpchk"
+		backendData.HttpchkParams = &models.HttpchkParams{
+			Method: "GET",
+			URI:    p.monitor.Path,
+		}
+	}
+
 	// Create Pool with pre-existing monitor
 	backendOK, _, err := p.haproxy.Backend.ReplaceBackend(&backend.ReplaceBackendParams{
-		Name: pool.Name,
-		Data: &models.Backend{
-			Name:     pool.Name,
-			AdvCheck: "httpchk",
-			Balance: &models.Balance{
-				Algorithm: &p.lbmethod,
-			},
-			Mode: "tcp",
-			HttpchkParams: &models.HttpchkParams{
-				Method: "GET",
-				URI:    p.monitor.Path,
-			},
-		},
+		Name:          pool.Name,
+		Data:          backendData,
 		Context:       p.ctx,
 		TransactionID: &p.transaction,
 	}, p.auth)


### PR DESCRIPTION
## Summary

The HAProxy backend provider unconditionally set `AdvCheck: "httpchk"` and`HttpchkParams` (GET on the monitor path) when creating or editing a pool. This forced an HTTP health check even for non-HTTP monitor types (e.g. `icmp`, `tcp`), producing invalid/incorrect health checking against those backends.

This change makes the httpchk configuration conditional: it is only applied when the monitor type is `http` or `https`. Other monitor types now fall back to HAProxy's default TCP-mode checking without an HTTP layer-7 check.

## Changes

- `CreatePool`: build the `Backend` struct first, then attach `AdvCheck` / `HttpchkParams` only for `http`/`https` monitor types.
- `EditPool`: same conditional logic for `ReplaceBackend`.

## Why

Applying an `httpchk` to an ICMP/TCP monitor is semantically wrong — the backend would be marked healthy/unhealthy based on an HTTP probe that the monitor type never intended.

## Testing

- [x] Pool with `http`/`https` monitor still gets httpchk configured
- [x] Pool with `icmp`/`tcp` monitor no longer sends httpchk params

